### PR TITLE
Update ananas.py to better handle missing configs

### DIFF
--- a/ananas/ananas.py
+++ b/ananas/ananas.py
@@ -1,4 +1,5 @@
 import os, sys, re, time, threading, _thread
+import warning
 import configparser, inspect, getpass, traceback
 from datetime import datetime, timedelta, timezone
 from html.parser import HTMLParser
@@ -162,7 +163,14 @@ class PineappleBot(StreamListener):
             self._filename = filename
             self._cfg = configparser.ConfigParser()
             self._bot = bot
-        def __getattr__(self, key): return self[key]
+        def __getattr__(self, key): 
+            if self[key]:
+                return self[key]
+            else:
+                warn("The {} setting does not appear in config.cfg. Setting the self.config value to None.",
+                     RuntimeWarning,
+                     1)
+                return None
         def __setattr__(self, key, value): self[key] = value
         def __delattr(self, key): del self[key]
 

--- a/ananas/ananas.py
+++ b/ananas/ananas.py
@@ -167,7 +167,7 @@ class PineappleBot(StreamListener):
             if self[key]:
                 return self[key]
             else:
-                warn("The {} setting does not appear in config.cfg. Setting the self.config value to None.",
+                warning.warn("The {} setting does not appear in config.cfg. Setting the self.config value to None.".format(key),
                      RuntimeWarning,
                      1)
                 return None


### PR DESCRIPTION
Currently, if a setting is not present, ananas throws a fatal error. This adjustment causes ananas to instead issue a warning and return None if the setting is not present in config.cfg. 

This allows for the following idiom:

    self.mysetting = self.config.mysetting if self.config.mysetting != None else <default>

which will be familiar to anyone who's initialized objects.