### PR TITLE
Adds a parameter to infer line breaks from tags

### DIFF
--- a/ananas/ananas.py
+++ b/ananas/ananas.py
@@ -140,8 +140,15 @@ class HTMLTextParser(HTMLParser):
     def handle_data(self, data):
         self.text += data;
 
-# TODO: add a parameter for whether to infer linebreaks from the html tags
-def html_strip_tags(html_str):
+def html_strip_tags(html_str, linebreaks=None):
+    linebreaks = False if linebreaks == None else bool(linebreaks)
+    if linebreaks:
+        html_str = re.sub(r"<br([^>]*)>",
+                          "\n<br\1>",
+                          html_str)
+        html_str = re.sub(r"<p([^>]*)>",
+                          "\n<p\1>",
+                          html_str)
     parser = HTMLTextParser()
     parser.feed(html_str)
     return parser.text


### PR DESCRIPTION
This converts `<br>` and `<p>` - including tags that have attributes - into line breaks. It preserves any additional attribute data in case future versions want to do something with it. The new attribute is optional, to preserve backward compatibility; omitting it will yield the old, no-conversion behavior.