### PR TITLE
Various helper functions for posting

### DIFF
--- a/ananas/ananas.py
+++ b/ananas/ananas.py
@@ -154,6 +154,24 @@ def html_strip_tags(html_str, linebreaks=None, lbchar=None):
     parser.feed(html_str)
     return parser.text
 
+def get_mentions(status_dict, exclude=[]):
+    """
+    Given a status dictionary, return all people mentioned in the toot,
+    excluding those in the list passed in exclude.
+    """
+    # Canonicalise the exclusion dictionary by lowercasing all names and
+    # removing leading @'s
+    for i, user in enumerate(exclude):
+        user = user.casefold()
+        if user[0] == "@":
+            user = user[1:]
+
+        exclude[i] = user
+
+    users = [user["username"] for user in status_dict["mentions"]
+             if user["username"].casefold() not in exclude]
+    return users
+
 class PineappleBot(StreamListener):
     """
     Main bot class

--- a/ananas/ananas.py
+++ b/ananas/ananas.py
@@ -239,7 +239,7 @@ class PineappleBot(StreamListener):
         self.mastodon = None
         self.account_info = None
         self.username = None
-        self.default_privacy = None
+        self.default_visibility = None
         self.default_sensitive = None
         self.stream = None
         self.interactive = interactive
@@ -324,7 +324,7 @@ class PineappleBot(StreamListener):
         credentials = self.mastodon.account_verify_credentials()
         self.account_info = credentials
         self.username = credentials["username"]
-        self.default_privacy = credentials["source"]["privacy"]
+        self.default_visibility = credentials["source"]["privacy"]
         self.default_sensitive = credentials["source"]["sensitive"]
 
         self.state = PineappleBot.RUNNING
@@ -432,17 +432,17 @@ class PineappleBot(StreamListener):
                     error = "Fatal exception: {}\n{}".format(repr(e), traceback.format_exc())
                     self.report_error(error, f.__name__)
 
-    def get_status_privacy(self, status_dict):
+    def get_reply_visibility(self, status_dict):
         """Given a status dict, return the visibility that should be used.
         This behaves like Mastodon does by default.
         """
         # Visibility rankings (higher is more limited)
         visibility = ("public", "unlisted", "private", "direct")
 
-        default_privacy = visibility.index(self.default_privacy)
-        status_privacy = visibility.index(status_dict["visibility"])
+        default_visibility = visibility.index(self.default_visibility)
+        status_visibility = visibility.index(status_dict["visibility"])
 
-        return visibility[max(default_privacy, status_privacy)]
+        return visibility[max(default_visibility, status_visibility)]
 
     # defaults, should be replaced by concrete bots with actual implementations
     # (if necessary, anyway)


### PR DESCRIPTION
get_mentions, given a status dict, will return a list of users that should be mentioned in the toot, except those in the exclusion list. This is most useful in conjunction with the new username member I added, which returns the bot's username.

get_reply_visibility gives you the privacy level that should be used for a reply, mimicking Mastodon's behaviour.