### PR TITLE
Auto-reconnect if the user stream dies (Fixes #2)

### DIFF
--- a/ananas/ananas.py
+++ b/ananas/ananas.py
@@ -405,7 +405,8 @@ class PineappleBot(StreamListener):
                 self.report_funcs.append(f)
 
         if len(self.reply_funcs) > 0:
-            self.stream = self.mastodon.stream_user(self, run_async=True)
+            self.stream = self.mastodon.stream_user(self, run_async=True,
+                                                    reconnect_async=True)
 
         credentials = self.mastodon.account_verify_credentials()
         self.account_info = credentials
@@ -537,7 +538,8 @@ class PineappleBot(StreamListener):
             try:
                 self.log(None, "Attempting to reinitialize in {}s...".format(wait))
                 time.sleep(wait)
-                self.stream = self.mastodon.stream_user(self, run_async=True)
+                self.stream = self.mastodon.stream_user(self, run_async=True,
+                                                        reconnect_async=True)
                 # Call the instance API first, so that we don't get stuck in stream_user
                 #  (timeout doesn't work there for some reason)
                 self.mastodon.instance()


### PR DESCRIPTION
Uses the new `reconnect_async` stream_* parameter that was added to Mastodon.py here: halcy/Mastodon.py@d0ae9dc

I've been using this for the past week with 3 bots, and haven't had to restart any of them (they definitely haven't all lasted this long before).

Fixes #2