### PR TITLE
fix Iterable import for python >=3.10

### DIFF
--- a/ananas/ananas.py
+++ b/ananas/ananas.py
@@ -2,7 +2,7 @@ import os, sys, re, time, threading, _thread
 import warnings, tempfile
 import configparser, inspect, getpass, traceback
 from datetime import datetime, timedelta, timezone
-from collections import Iterable
+from collections.abc import Iterable
 from html.parser import HTMLParser
 import mastodon
 from mastodon import Mastodon, StreamListener


### PR DESCRIPTION
collection abstract base classes were moved to `collections.abc` in
python 3.3 and importing ABCs directly from `collections` was deprecated
then and removed in 3.10

<https://docs.python.org/3/whatsnew/3.3.html#collections>

<https://docs.python.org/3/whatsnew/3.10.html#removed>